### PR TITLE
[Bugfix] fix variable substitution in click and double click action and component call inside component

### DIFF
--- a/static/driver.js
+++ b/static/driver.js
@@ -1,6 +1,8 @@
 const Actions = require('./actiondata').ActionsByConstant;
 const TIMEOUT = 5000;
 
+var Variables = require('./variables.js');
+
 module.exports.bindDriver = function(browser) {
 
   var oldBack = browser.back;
@@ -1734,8 +1736,29 @@ module.exports.bindDriver = function(browser) {
       checkForDomComplete();
 
       return browser;
+    },
+	
+	"component": (name, instanceVars) => {
+  	  browser.perform(() => {
+		Object.keys(instanceVars).map(function(key) {
+			instanceVars[key] = renderWithVars(instanceVars[key], getVars(browser))
+		});
+	  
+  	    // get defaults
+  	    var component = browser.components[name];
+  	    var defaultsVars = component.defaults;
+  	    var compVars = Variables.CompVars(browser.vars, defaultsVars, instanceVars)
+      
+  	    // call the component, pushing the new var context onto a stack.
+  	    browser.compVarStack.push(compVars);
+      
+  	    component.actions();
+      
+  	  })
+      
+  	  return browser;
+  
     }
-
   };
 
   /* ***************************************************************************************

--- a/static/driver.js
+++ b/static/driver.js
@@ -765,6 +765,7 @@ module.exports.bindDriver = function(browser) {
         if (blockCancelled(browser)) return;
 
         var then = Date.now();
+		selector = renderWithVars(selector, getVars(browser));
         var techDescription = `${Actions["MOUSEDOWN"].name} ... using "${selector}" (${selectorType})`;
 
         browser._elementPresent(selector, selectorType, null, timeout,
@@ -825,6 +826,7 @@ module.exports.bindDriver = function(browser) {
         if (blockCancelled(browser)) return;
 
         var then = Date.now();
+		selector = renderWithVars(selector, getVars(browser));
         var techDescription = `${Actions["DOUBLECLICK"].name} ... using "${selector}" (${selectorType})`;
 
         browser._elementPresent(selector, selectorType, null, timeout,

--- a/templates/components.js
+++ b/templates/components.js
@@ -19,23 +19,4 @@ module.exports.bindComponents = function(browser) {
   }
 <% }); %>
 
-  browser.component = (name, instanceVars) => {
-    browser.perform(() => {
-
-      // get defaults
-      var component = browser.components[name];
-      var defaultsVars = component.defaults;
-      var compVars = Variables.CompVars(browser.vars, defaultsVars, instanceVars)
-
-      // call the component, pushing the new var context onto a stack.
-      browser.compVarStack.push(compVars);
-
-      component.actions();
-
-    })
-
-    return browser;
-
-  }
-
 };


### PR DESCRIPTION
I add a small fix to support variable substitution inside action click and doubleClick.

Besides, I add ability to do variable substitution inside component call. Previously this component definition won't work

```
actions: () => {
      return browser
        .component("Select a platform package", {platform_name: `Fanpage`, platform_package: `\${platform_fanpage} fanpage`})
        .endComponent();
    }
```

With this implementation the `platform_package` will be transform to "x fanpage" (assume that $platform_fanpage = "x").